### PR TITLE
Move set user-agent upper

### DIFF
--- a/request.go
+++ b/request.go
@@ -13,11 +13,11 @@ func (c *Client) Send() *response.Sugar {
 
 	plugins := []request.Plugin{
 		request.URL{Data: c.URL},
+		request.UserAgent{Version: Version},
 		request.Query{Data: c.Query},
 		request.Method{Data: c.Method},
 		request.Header{Data: c.Header},
 		request.SortedHeader{Data: c.SortedHeader},
-		request.UserAgent{Version: Version},
 		request.Cookies{Data: c.Cookies, Map: c.CookiesMap},
 		request.BearerAuth{Data: c.Bearer},
 		request.CustomerAuth{},


### PR DESCRIPTION
Dont work this one.

```
	client2 := request.Client{
		URL:    "https://update-api.1c.ru/update-platform/programs/update/",
		Method: "POST",
		Header: map[string]string{
			"Content-Type": "application/json",
			"User-Agent": "1C+Enterprise/8.3",
		},
	}

```

Move setup User_Agent header upper appy headers